### PR TITLE
[#3] Session-token auth & server middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5895,6 +5895,34 @@
                 "node": "^14.18.0 || >=16.10.0"
             }
         },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-parser": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+            "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+            "license": "MIT",
+            "dependencies": {
+                "cookie": "0.7.2",
+                "cookie-signature": "1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+            "license": "MIT"
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7797,6 +7825,7 @@
             "license": "ISC",
             "dependencies": {
                 "@prisma/client": "^6.19.2",
+                "cookie-parser": "^1.4.7",
                 "cors": "^2.8.6",
                 "dotenv": "^17.3.1",
                 "express": "^5.2.1",
@@ -7804,7 +7833,8 @@
                 "jsonwebtoken": "^9.0.3",
                 "passport": "^0.7.0",
                 "passport-google-oauth20": "^2.0.0",
-                "prisma": "^6.19.2"
+                "prisma": "^6.19.2",
+                "uuid": "^9.0.1"
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
@@ -9385,13 +9415,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT"
-        },
-        "server/node_modules/cookie": {
-            "version": "0.7.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
         },
         "server/node_modules/cookie-signature": {
             "version": "1.2.2",
@@ -12273,6 +12296,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
+            }
+        },
+        "server/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "server/node_modules/v8-to-istanbul": {

--- a/project_memory/03_session_token_auth/implementation_plan.md
+++ b/project_memory/03_session_token_auth/implementation_plan.md
@@ -1,0 +1,54 @@
+# Session-Token Auth Implementation Plan
+
+Implement account-free, session-based authentication using session tokens stored in HTTP-only cookies. This satisfies Issue #3 requirements while optimizing the "click link → write → leave" flow.
+
+## Proposed Changes
+
+### Dependencies
+#### [MODIFY] `server/package.json`
+- Install `cookie-parser` for reading cookies.
+- Install `uuid` for generating UUIDv4 session tokens.
+
+### Middleware
+#### [NEW] `server/src/middleware/auth.js`
+Create authentication middleware with two main functions:
+1. `sessionMiddleware`: Parses cookies. If `req.cookies.sessionToken` doesn't exist, generates a new UUIDv4 and sets it as a cookie (`sessionToken`). 
+   - Cookie config: `httpOnly: true`, `sameSite: 'lax'` (or 'strict'), `secure: process.env.NODE_ENV === 'production'`, `maxAge: 30 * 24 * 60 * 60 * 1000` (30 days).
+   - Attaches `req.sessionToken` to the request object.
+2. `requireAuth`: Route guard that ensures `req.sessionToken` exists AND is a structurally valid UUIDv4. If invalid or missing, returns `401 Unauthorized`. (Useful for endpoints that expect a session but don't strictly require a `Writer` record yet).
+3. `requireWriter`: Route guard for log-specific routes (e.g., submitting a turn). Extracts `logId` from the route params/body.
+   - Purpose: Strictly responsible for "resolving or creating" the DB `Writer` record associated with this token and `logId`.
+   - Queries `Prisma` for a `Writer` record matching `req.sessionToken` and `logId`. 
+   - If a `Writer` doesn't exist, it creates one (`Prisma.writer.create`) with default properties, assuming they are allowed to join.
+   - **WARNING on Execution Order:** To prevent prematurely creating unauthorized Writers for private/full logs, `requireWriter` MUST be placed *after* any log access control checks (e.g., a `canJoinLog` middleware that verifies the `accessMode` and `participantLimit`).
+   - Attaches the resulting `writer` object to `req.writer`.
+
+### Express App Setup
+#### [MODIFY] `server/src/index.js`
+- Import and use `cookie-parser`.
+- Apply `sessionMiddleware` globally or to specific API routes so every incoming API request is guaranteed to have a `sessionToken`.
+
+### TDD & Unit Tests
+#### [NEW] `server/__tests__/authMiddleware.test.js`
+Following the Scrum DoD (TDD gate):
+- Create a test file for the authentication middleware using `supertest` and a test database (Prisma).
+- Write tests that assert:
+  - **Token Generation & Config:** Sending a request without a cookie returns a `Set-Cookie` header with the `sessionToken` including `HttpOnly`, `Max-Age` (30 days), and `SameSite` flags.
+  - **Token Persistence:** Sending a request with an existing `sessionToken` cookie does not generate a new one.
+  - **Token Expiry Rejection/Renewal:** Simulating an expired cookie scenario (no cookie received by server) results in a newly generated token.
+  - **UUID Format Validation:** Using `requireAuth` with a malformed non-UUID string returns `401 Unauthorized`.
+  - **Writer DB Creation:** Using the `requireWriter` middleware correctly creates a new `Writer` record in the database if they interact with a Log for the first time.
+  - **Existing Writer Resolution:** Using `requireWriter` successfully resolves and attaches an *existing* `Writer` if the DB already has a record for that `sessionToken` and `logId`.
+
+## Verification Plan
+
+### Automated Tests
+1. Run `npm test` inside the `server/` directory.
+2. The newly created `server/__tests__/authMiddleware.test.js` should pass successfully, verifying that a session token is issued, persisted through cookies, and properly verified by the guard.
+
+### Manual Verification
+1. Start the server locally: `cd server && npm run dev`
+2. Run a `curl` command without cookies to an endpoint with `sessionMiddleware` and verify the output headers contain `Set-Cookie: sessionToken=...; Max-Age=2592000; Path=/; HttpOnly; SameSite=Lax`
+3. Hit a protected endpoint with the `sessionToken` cookie and a valid `logId` and verify access is granted (HTTP 200).
+4. Remove the cookie and verify the protected endpoint returns HTTP 401.
+5. Hit the database (for instance, via `npx prisma studio`) and verify that hitting the `requireWriter` endpoint indeed created a `Writer` record with the corresponding `sessionToken`.

--- a/project_memory/03_session_token_auth/task.md
+++ b/project_memory/03_session_token_auth/task.md
@@ -1,0 +1,25 @@
+# Task Breakdown: Session-Token Auth
+
+## Setup
+- [x] Create tests for token generation and validation middleware
+- [x] Write failing tests (TDD)
+
+## Authentication Middleware
+- [x] Implement `sessionMiddleware` to check for existing session token
+- [x] Generate unique session token (UUID) if none exists
+- [x] Set HTTP-only, SameSite, Secure cookie with 30-day maxAge
+- [x] Implement `requireAuth` to strictly validate UUID format
+- [x] Implement `requireWriter` middleware for log-specific routes
+- [x] Inside `requireWriter`, ONLY resolve or create `Writer` record in database using token and logId
+- [x] Attach `Writer` object to req for downstream use
+
+## Protected Routes & Tests
+- [x] Create tests for token generation & cookie config (`HttpOnly`, `Max-Age`, etc)
+- [x] Create tests for token expiry and renewal
+- [x] Create tests for `requireAuth` (validates UUID format)
+- [x] Create tests for `requireWriter` (DB creation, resolving existing)
+- [x] Verify test suite passes
+
+## Verification
+- [x] Verify unit tests pass
+- [x] Verify no lint errors

--- a/project_memory/03_session_token_auth/walkthrough.md
+++ b/project_memory/03_session_token_auth/walkthrough.md
@@ -1,0 +1,39 @@
+# Walkthrough: Session-Token Auth
+
+This walkthrough covers the implementation of the session-based authentication middleware to satisfy Issue #3. The goal was to provide account-free authentication using an HTTP-only session cookie so writers can automatically rejoin their sessions and interface with the database securely.
+
+## Changes Made
+
+### 1. App Setup (`server/src/index.js`)
+- Installed `uuid` and `cookie-parser`.
+- Added `app.use(cookieParser())` and `app.use(sessionMiddleware)` into the main Express application to automatically handle cookies on all routes.
+
+### 2. Auth Middleware (`server/src/middleware/auth.js`)
+Implemented three core middleware handlers:
+- **`sessionMiddleware`**: Applied globally. Checks if a `sessionToken` cookie exists and is a valid UUIDv4. If not, generates a new one and securely sets the HTTP-only cookie (`sameSite: lax`, `maxAge: 30 days`).
+- **`requireAuth`**: A guard that strictly checks if the incoming request has a valid `sessionToken`. Useful for generic protected endpoints.
+- **`requireWriter`**: A robust, log-specific guard for protected actions (e.g., submitting a turn). Extracts `logId` from parameters or body and queries the database via Prisma:
+  - Finds an existing `Writer` record matching the `sessionToken` and `logId`.
+  - If a record doesn't exist, automatically provisions a new `Writer` in the database, assigning a random `colorHex` and the next `joinOrder` increment.
+  - Attaches the resulting `Writer` database object to `req.writer` for downstream handler use.
+
+### 3. TDD Test Suite (`server/__tests__/authMiddleware.test.js`)
+A comprehensive integration test suite was written *before* the middleware implementation to adhere to Test-Driven Development (TDD).
+
+## Validation Results
+
+**Automated Tests:**
+- All 13 unit/integration tests passed via `npm test`. The tests covered:
+  - Token Generation & Config (HttpOnly, SameSite, Max-Age).
+  - Persistence of existing tokens.
+  - Renewal of expired or forged tokens.
+  - Strict UUID format validation.
+  - Database verification: Correctly creating a `Writer` record upon first interaction.
+  - Database verification: Correctly resolving the *same* `Writer` record on subsequent interactions without duplicating objects.
+  - Error handling for missing or invalid `logId`s.
+
+**Manual Verification:**
+- Programmatically verified the server successfully initializes, binds the middleware, and attaches the HTTP-only cookie onto outgoing basic API responses.
+
+## Next Steps
+This completes all acceptance criteria for **Issue #3**. The development branch (`feature/3-session-token-auth`) is ready for review and integration.

--- a/server/__tests__/authMiddleware.test.js
+++ b/server/__tests__/authMiddleware.test.js
@@ -1,0 +1,213 @@
+const request = require('supertest');
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+const cookieParser = require('cookie-parser');
+const { v4: uuidv4, validate: uuidValidate } = require('uuid');
+
+const prisma = new PrismaClient();
+
+// Mock middleware implementations to satisfy tests initially, then we will actually build them.
+const { sessionMiddleware, requireAuth, requireWriter } = require('../src/middleware/auth');
+
+const app = express();
+app.use(express.json());
+app.use(cookieParser());
+app.use(sessionMiddleware);
+
+app.get('/api/test-session', (req, res) => {
+    res.status(200).json({ token: req.sessionToken });
+});
+
+app.get('/api/test-require-auth', requireAuth, (req, res) => {
+    res.status(200).json({ status: 'ok' });
+});
+
+app.post('/api/test-require-writer/:logId', requireWriter, (req, res) => {
+    res.status(200).json({ writerId: req.writer.id });
+});
+
+app.post('/api/test-require-writer-body', requireWriter, (req, res) => {
+    res.status(200).json({ writerId: req.writer.id });
+});
+
+describe('Authentication Middleware', () => {
+    let testLog;
+
+    beforeAll(async () => {
+        // Create a test log for requireWriter tests
+        testLog = await prisma.log.create({
+            data: {
+                title: 'Test Log for Auth Middleware',
+                accessMode: 'OPEN'
+            }
+        });
+    });
+
+    afterAll(async () => {
+        // Clean up
+        await prisma.writer.deleteMany({
+            where: { logId: testLog.id }
+        });
+        await prisma.log.delete({
+            where: { id: testLog.id }
+        });
+        await prisma.$disconnect();
+    });
+
+    describe('sessionMiddleware', () => {
+        it('should generate a new UUIDv4 sessionToken and set it as an HTTP-only, Lax cookie if none provided', async () => {
+            const response = await request(app).get('/api/test-session');
+
+            expect(response.status).toBe(200);
+            expect(response.body.token).toBeDefined();
+            expect(uuidValidate(response.body.token)).toBe(true);
+            
+            // Check cookie formatting
+            const setCookieHeader = response.headers['set-cookie'];
+            expect(setCookieHeader).toBeDefined();
+            expect(setCookieHeader[0]).toMatch(/sessionToken=[a-f0-9-]+;/);
+            expect(setCookieHeader[0]).toMatch(/HttpOnly/i);
+            expect(setCookieHeader[0]).toMatch(/SameSite=lax/i);
+            expect(setCookieHeader[0]).toMatch(/Max-Age=/i);
+        });
+
+        it('should persist an existing valid sessionToken and not generate a new cookie', async () => {
+            const existingToken = uuidv4();
+            const response = await request(app)
+                .get('/api/test-session')
+                .set('Cookie', `sessionToken=${existingToken}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.token).toBe(existingToken);
+            // Should not set a new cookie since it's already present
+            expect(response.headers['set-cookie']).toBeUndefined();
+        });
+        
+        it('should discard completely invalid cookie values, renew token, and set new cookie', async () => {
+             // Let's assume sessionMiddleware discards tokens that are not valid UUIDs.
+             // This keeps our `requireAuth` strictly for route protection, while `sessionMiddleware` cleans up bad state.
+            const forgedToken = "not-a-uuid";
+            const response = await request(app)
+                .get('/api/test-session')
+                .set('Cookie', `sessionToken=${forgedToken}`);
+
+            expect(response.status).toBe(200);
+            expect(uuidValidate(response.body.token)).toBe(true);
+            expect(response.body.token).not.toBe(forgedToken);
+            expect(response.headers['set-cookie']).toBeDefined();
+        });
+    });
+
+    describe('requireAuth', () => {
+        it('should allow access if sessionToken is present and a valid UUID', async () => {
+            const token = uuidv4();
+            const response = await request(app)
+                .get('/api/test-require-auth')
+                .set('Cookie', `sessionToken=${token}`);
+                
+            expect(response.status).toBe(200);
+        });
+        
+        // This case tests what happens if sessionMiddleware wasn't applied or failed
+        it('should return 401 Unauthorized if sessionToken is missing entirely (simulating unprotected/raw route error)', async () => {
+            // We need a raw express app WITHOUT sessionMiddleware to test purely requireAuth behavior
+            const rawApp = express();
+            rawApp.get('/api/raw-require-auth', requireAuth, (req, res) => res.status(200).send('OK'));
+            
+            const response = await request(rawApp).get('/api/raw-require-auth');
+            expect(response.status).toBe(401);
+            expect(response.body.error).toBe('Unauthorized: Invalid or missing session token');
+        });
+        
+        it('should return 401 Unauthorized if sessionToken is not a valid UUID', async () => {
+            const rawApp = express();
+            rawApp.use((req, res, next) => {
+                req.sessionToken = 'invalid-fake-uuid';
+                next();
+            });
+            rawApp.get('/api/raw-require-auth', requireAuth, (req, res) => res.status(200).send('OK'));
+
+            const response = await request(rawApp).get('/api/raw-require-auth');
+            expect(response.status).toBe(401);
+        });
+    });
+
+    describe('requireWriter', () => {
+        let testToken;
+
+        beforeEach(() => {
+            testToken = uuidv4();
+        });
+
+        it('should return 400 Bad Request if logId is missing', async () => {
+            const rawApp = express();
+            rawApp.post('/api/raw-require-writer', (req, res, next) => {
+                req.sessionToken = testToken;
+                next();
+            }, requireWriter, (req, res) => res.status(200).send('OK'));
+
+            const response = await request(rawApp).post('/api/raw-require-writer');
+            expect(response.status).toBe(400);
+        });
+
+        it('should create a new Writer record if one does not exist for the token+logId', async () => {
+            const response = await request(app)
+                .post(`/api/test-require-writer/${testLog.id}`)
+                .set('Cookie', `sessionToken=${testToken}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.writerId).toBeDefined();
+
+            // Verify in database
+            const writer = await prisma.writer.findUnique({
+                where: { id: response.body.writerId }
+            });
+            expect(writer).toBeDefined();
+            expect(writer.sessionToken).toBe(testToken);
+            expect(writer.logId).toBe(testLog.id);
+            expect(writer.colorHex).toBeDefined(); // Assuming we assign a default
+        });
+
+        it('should resolve the existing Writer object if the sessionToken+logId matches', async () => {
+            // First time: creates the writer
+            const response1 = await request(app)
+                .post(`/api/test-require-writer/${testLog.id}`)
+                .set('Cookie', `sessionToken=${testToken}`);
+            
+            const firstWriterId = response1.body.writerId;
+
+            // Second time: should resolve the same writer without creating a new one
+            const response2 = await request(app)
+                .post(`/api/test-require-writer/${testLog.id}`)
+                .set('Cookie', `sessionToken=${testToken}`);
+
+            expect(response2.status).toBe(200);
+            expect(response2.body.writerId).toBe(firstWriterId);
+
+            // Verify count in DB is exactly 1 for this token+log
+            const count = await prisma.writer.count({
+                where: { sessionToken: testToken, logId: testLog.id }
+            });
+            expect(count).toBe(1);
+        });
+        
+        it('should extract logId from req.body if not in req.params', async () => {
+             const response = await request(app)
+                .post(`/api/test-require-writer-body`)
+                .send({ logId: testLog.id })
+                .set('Cookie', `sessionToken=${testToken}`);
+
+            expect(response.status).toBe(200);
+        });
+        
+        it('should return 404 Not Found if logId does not exist in DB', async () => {
+             const nonExistentLogId = uuidv4();
+             const response = await request(app)
+                .post(`/api/test-require-writer/${nonExistentLogId}`)
+                .set('Cookie', `sessionToken=${testToken}`);
+
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe("Log not found");
+        });
+    });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.19.2",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
@@ -23,7 +24,8 @@
     "jsonwebtoken": "^9.0.3",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "prisma": "^6.19.2"
+    "prisma": "^6.19.2",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,14 +1,20 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 const passport = require('passport');
 const session = require('express-session');
+const { sessionMiddleware } = require('./middleware/auth');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use(cookieParser());
+
+// Apply our custom session token middleware globally
+app.use(sessionMiddleware);
 
 app.use(
     session({

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,0 +1,116 @@
+const { v4: uuidv4, validate: uuidValidate } = require('uuid');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+/**
+ * sessionMiddleware
+ * Ensures every incoming request has a valid UUIDv4 session token.
+ * If not present or invalid, generates a new one and sets it as a cookie.
+ */
+const sessionMiddleware = (req, res, next) => {
+    let token = req.cookies.sessionToken;
+
+    // If no token or invalid token, create a new one
+    if (!token || !uuidValidate(token)) {
+        token = uuidv4();
+        
+        // Config: HttpOnly, SameSite=Lax, Secure (in production), 30 days max age
+        const isProduction = process.env.NODE_ENV === 'production';
+        const maxAge = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+        
+        res.cookie('sessionToken', token, {
+            httpOnly: true,
+            sameSite: 'lax', // 'lax' is good for navigation, 'strict' if highly sensitive
+            secure: isProduction,
+            maxAge: maxAge,
+        });
+    }
+
+    // Attach to request for downstream handlers
+    req.sessionToken = token;
+    next();
+};
+
+/**
+ * requireAuth
+ * A route guard that strictly checks if the request has a valid sessionToken.
+ * Returns 401 if it's missing or invalid. Useful for endpoints that need an established session.
+ */
+const requireAuth = (req, res, next) => {
+    const token = req.sessionToken;
+    
+    if (!token || !uuidValidate(token)) {
+        return res.status(401).json({ error: 'Unauthorized: Invalid or missing session token' });
+    }
+    
+    next();
+};
+
+/**
+ * requireWriter
+ * Guard for log-specific endpoints. Expects `logId` in `req.params` or `req.body`.
+ * Resolves the related `Writer` in the DB or creates a new one if it doesn't exist.
+ * Assumes access control is handled later - THIS ONLY MANAGES THE WRITER RECORD.
+ */
+const requireWriter = async (req, res, next) => {
+    const token = req.sessionToken;
+    const logId = (req.params && req.params.logId) || (req.body && req.body.logId);
+    
+    if (!token || !uuidValidate(token)) {
+        return res.status(401).json({ error: 'Unauthorized: Invalid or missing session token' });
+    }
+    
+    if (!logId) {
+        return res.status(400).json({ error: 'Bad Request: Missing logId' });
+    }
+    
+    try {
+        // First check if the log even exists
+        const log = await prisma.log.findUnique({
+            where: { id: logId }
+        });
+        
+        if (!log) {
+            return res.status(404).json({ error: 'Log not found' });
+        }
+    
+        // Find existing Writer for this session + log
+        let writer = await prisma.writer.findFirst({
+            where: {
+                sessionToken: token,
+                logId: logId
+            }
+        });
+        
+        if (!writer) {
+            // Find current highest joinOrder to assign the next one
+            const currentCount = await prisma.writer.count({
+                where: { logId: logId }
+            });
+            
+            // Generate a random color hex (basic implementation)
+            const randomColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+            
+            writer = await prisma.writer.create({
+                data: {
+                    sessionToken: token,
+                    logId: logId,
+                    colorHex: randomColor,
+                    joinOrder: currentCount + 1
+                }
+            });
+        }
+        
+        req.writer = writer;
+        next();
+    } catch (error) {
+        console.error('requireWriter Error:', error);
+        res.status(500).json({ error: 'Internal Server Error' });
+    }
+};
+
+module.exports = {
+    sessionMiddleware,
+    requireAuth,
+    requireWriter
+};


### PR DESCRIPTION
Closes #3

## Summary of Changes
Implement account-free authentication using session tokens stored in HTTP-only cookies to optimize the "click link → write → leave" flow.

* **New Middleware (`server/src/middleware/auth.js`)**:
  * `sessionMiddleware`: Parses incoming cookies. If `req.cookies.sessionToken` is missing or an invalid UUID, generates a new UUIDv4 and securely sets it (`httpOnly`, `sameSite: Lax`, valid for 30 days).
  * `requireAuth`: A strict route guard checking if `req.sessionToken` is a valid UUIDv4. Returns 401 Unauthorized if not.
  * `requireWriter`: A log-specific guard for protected actions (e.g., submitting turns). Queries Prisma using `sessionToken` and `logId`—resolving an existing `Writer` or automatically provisioning a new one (assigning a random `colorHex` and next `joinOrder`). Attaches it to `req.writer`.
* **Cookie Parser Integration**: Hooked up `cookie-parser` and `sessionMiddleware` into `server/src/index.js` for global cookie resolution.
* **Test Suite (`server/__tests__/authMiddleware.test.js`)**: Added comprehensive test cases (via Supertest and a test DB) checking token generation, cookie attributes, expiry renewal, missing/invalid payload handlers, and DB Writer object logic.