### PR TITLE
[#16] feat(auth): S2-1 — user registration, JWT + Google OAuth

### DIFF
--- a/.agents/skills/project-context.md
+++ b/.agents/skills/project-context.md
@@ -1,0 +1,107 @@
+# Project Instructions — Collective Unconscious
+
+## What This Project Is
+
+**Collective Unconscious** is an async collaborative chain-writing platform. Users create or join "logs" — turn-based writing sessions where each participant adds to a shared piece one segment at a time. Each participant's text is displayed in a distinct color. Completed works can be shared publicly. Logs can be public or invite-only, with optional rules around turn order, round limits, and creative constraints.
+
+---
+
+## Core Concepts (Always Keep In Mind)
+
+- **Log** — the central product object; a single chain-writing session with a defined set of participants, a turn queue, and an immutable transcript of contributions
+- **Turn** — one participant's contribution to a log; submitted and locked (no editing after the fact)
+- **Prompt** — a creative seed for a new log; either platform-issued (curated/editorial) or user-submitted
+- **Color coding** — each participant in a log is assigned a unique color that persists throughout the log and is visible in the final work
+
+---
+
+## Target Personas
+
+1. **The Social Writer** — wants to write with friends asynchronously without group-chat noise
+2. **The Pattern-Breaker** — wants to write with strangers to escape their own creative habits
+3. **The Low-Pressure Connector** — seeks meaningful social connection through shared creation
+
+---
+
+## Product Scope
+
+### In Scope (v1)
+- Log creation with configurable settings (public/invite-only, turn order, round limits, constraints)
+- Async turn-taking with notifications (email minimum)
+- Per-participant color coding
+- Platform-curated and user-submitted prompts
+- Discovery feed for completed public works
+- Reactions and comments on completed works
+- Public shareable links (viewable without login)
+- User profiles
+
+### Out of Scope (v1)
+- Real-time simultaneous editing
+- Audio/multimedia contributions
+- AI-assisted writing or AI turns
+- Mobile native apps (web-first)
+- Paid tiers or monetization
+- Content translation
+
+---
+
+## Key Product Decisions & Defaults
+
+| Setting | Default |
+|---|---|
+| Log visibility | Creator's choice (public or invite-only) |
+| Turn order | Sequential (configurable) |
+| Round limit | Unlimited (configurable) |
+| Turn timeout | TBD — open question |
+| Word/character limit per turn | TBD — open question |
+| Color assignment | TBD — open question (random from palette, or user-chosen) |
+
+---
+
+## User Stories Reference
+
+| ID | Story |
+|---|---|
+| US-01 | Play with friends (invite-only) or discover strangers (public logs) |
+| US-02 | Access platform-issued themed prompts as creative starting points |
+| US-03 | Publish personal prompts for the community |
+| US-04 | React to and comment on completed works |
+| US-05 | Be visually distinguished by color within a log |
+
+---
+
+## Tone & Voice
+
+This product is for creative people who value expression over productivity. When helping with copy, naming, UX flows, or design:
+
+- Lean **poetic and minimal** — avoid corporate, gamified, or social-media-growth language
+- Embrace **strangeness and surprise** — the platform is about unexpected creative collisions
+- Keep UI copy **short and human** — think literary journal, not SaaS dashboard
+- The name "Collective Unconscious" signals depth, collaboration, and the subconscious creative process — let that spirit inform everything
+
+---
+
+## Open Questions (Don't Resolve Without Flagging)
+
+These are unresolved and should be surfaced when relevant rather than assumed:
+
+- Default turn timeout duration before a participant is skipped
+- Color assignment UX (random, palette-pick, or fully user-controlled)
+- Min/max word count per turn (platform default vs. creator-set)
+- Content moderation approach for public logs and comments
+- What happens to abandoned logs
+- Whether any game mechanics (streaks, badges) belong in v1
+
+---
+
+## How to Help
+
+When working on this project, Claude may be asked to assist with:
+
+- **Product** — feature specs, user flows, edge case analysis, prioritization
+- **Design** — wireframe descriptions, UX copy, naming, color palette suggestions
+- **Engineering** — data models, API design, tech stack recommendations, architecture
+- **Content** — prompt writing, onboarding copy, marketing language, FAQ drafts
+- **Research** — competitive landscape, analogous products, user interview questions
+
+Always ground responses in the personas, the core concept of async chain-writing, and the literary/creative ethos of the product.

--- a/.agents/skills/stack.md
+++ b/.agents/skills/stack.md
@@ -1,0 +1,8 @@
+# Stack
+- Frontend: React 18, Vite, React Router v6
+- Backend: Node.js + Express
+- Database: PostgreSQL via Prisma ORM
+- Auth: JWT (access + refresh tokens) + Google OAuth via Passport.js
+- Testing: Vitest (frontend), Jest + Supertest (backend)
+- CI/CD: GitHub Actions
+- Containerization: Docker Compose for local dev (pg + api + client)

--- a/.agents/skills/tdd-workflow.md
+++ b/.agents/skills/tdd-workflow.md
@@ -1,0 +1,5 @@
+# TDD Rules
+- Write failing tests BEFORE implementation code
+- Every API route needs an integration test via Supertest
+- Every React component needs at minimum a render test
+- Do not mark a task complete unless tests pass

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 # Python / Gemini Agent generated files
 .gemini/
 __pycache__/
-
 # Agent workflows and skills
 .agents/
+
+server/.env

--- a/prisma/migrations/20260311211243_add_user_and_refresh_token/migration.sql
+++ b/prisma/migrations/20260311211243_add_user_and_refresh_token/migration.sql
@@ -1,0 +1,42 @@
+-- AlterTable
+ALTER TABLE "Writer" ADD COLUMN     "userId" TEXT;
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "googleId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "bio" TEXT,
+    "avatarUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RefreshToken" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_googleId_key" ON "User"("googleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RefreshToken_token_key" ON "RefreshToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Writer" ADD CONSTRAINT "Writer_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,16 +41,44 @@ model Log {
   turns              Turn[]
 }
 
+model User {
+  id          String   @id @default(uuid())
+  googleId    String   @unique
+  email       String   @unique
+  displayName String
+  bio         String?
+  avatarUrl   String?
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  writers      Writer[]
+  refreshTokens RefreshToken[]
+}
+
+model RefreshToken {
+  id        String   @id @default(uuid())
+  token     String   @unique  // Stored as the raw JWT (consider hashing in prod)
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+}
+
 model Writer {
   id           String   @id @default(uuid())
   sessionToken String   // Link to an anonymous session
-  
+
   nickname     String?  // E.g., "Musing Crow"
   colorHex     String   // E.g., "#FF8C00"
-  
+
   logId        String
   log          Log      @relation(fields: [logId], references: [id], onDelete: Cascade)
-  
+
+  // Optional link to a registered User account (null for anonymous writers)
+  userId       String?
+  user         User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+
   joinOrder    Int      // 1 for creator (keeper), 2 for second participant...
 
   createdAt    DateTime @default(now())

--- a/server/__tests__/auth.test.js
+++ b/server/__tests__/auth.test.js
@@ -1,0 +1,150 @@
+/**
+ * S2-1: Auth endpoint tests (TDD — written before implementation)
+ * Tests for Google OAuth flow, JWT token management, and /me endpoint.
+ */
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+// We mock passport and prisma so tests don't require live Google or a real DB
+jest.mock('passport', () => ({
+  initialize: () => (req, res, next) => next(),
+  session: () => (req, res, next) => next(),
+  authenticate: (strategy, options) => (req, res, next) => {
+    if (strategy === 'google') {
+      if (options && options.failureRedirect) {
+        // Simulate callback: attach mock user then call next
+        req.user = { id: 'mock-user-id', displayName: 'Test User', email: 'test@gmail.com' };
+        return next();
+      }
+      // Simulate redirect to Google
+      return res.redirect('https://accounts.google.com/oauth/authorize?mock=true');
+    }
+    next();
+  },
+  use: jest.fn(),
+  serializeUser: jest.fn(),
+  deserializeUser: jest.fn(),
+}));
+
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      upsert: jest.fn(),
+      update: jest.fn(),
+    },
+    refreshToken: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    writer: {
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    $disconnect: jest.fn(),
+  };
+  return { PrismaClient: jest.fn(() => mockPrisma) };
+});
+
+const { PrismaClient } = require('@prisma/client');
+const prismaMock = new PrismaClient();
+
+const JWT_SECRET = 'test-secret';
+process.env.JWT_SECRET = JWT_SECRET;
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+process.env.SESSION_SECRET = 'test-session-secret';
+process.env.GOOGLE_CLIENT_ID = 'mock-client-id';
+process.env.GOOGLE_CLIENT_SECRET = 'mock-client-secret';
+process.env.GOOGLE_CALLBACK_URL = 'http://localhost:3000/api/auth/google/callback';
+process.env.CLIENT_URL = 'http://localhost:5173';
+
+const app = require('../src/index');
+
+describe('Auth Routes — S2-1', () => {
+
+  describe('GET /api/auth/google', () => {
+    it('should redirect to Google OAuth URL', async () => {
+      const res = await request(app).get('/api/auth/google');
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toMatch(/accounts\.google\.com/);
+    });
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('should return current user when a valid JWT access token is provided', async () => {
+      const mockUser = { id: 'user-1', displayName: 'Test User', email: 'test@gmail.com', bio: null, avatarUrl: null };
+      prismaMock.user.findUnique.mockResolvedValue(mockUser);
+
+      const token = jwt.sign({ userId: 'user-1' }, JWT_SECRET, { expiresIn: '15m' });
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Cookie', `accessToken=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: 'user-1', displayName: 'Test User', email: 'test@gmail.com' });
+      // Should never expose sensitive fields
+      expect(res.body.googleId).toBeUndefined();
+    });
+
+    it('should return 401 if no access token is provided', async () => {
+      const res = await request(app).get('/api/auth/me');
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 401 if access token is expired/invalid', async () => {
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Cookie', 'accessToken=totally.invalid.token');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/refresh', () => {
+    it('should return a new access token given a valid refresh token', async () => {
+      const storedToken = { token: 'hashed-refresh', userId: 'user-1', expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) };
+      prismaMock.refreshToken.findUnique.mockResolvedValue(storedToken);
+      prismaMock.refreshToken.delete.mockResolvedValue({});
+      prismaMock.refreshToken.create.mockResolvedValue({});
+
+      const refreshToken = jwt.sign({ userId: 'user-1' }, process.env.JWT_REFRESH_SECRET, { expiresIn: '7d' });
+      const res = await request(app)
+        .post('/api/auth/refresh')
+        .set('Cookie', `refreshToken=${refreshToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.accessToken).toBeDefined();
+    });
+
+    it('should return 401 if refresh token is missing', async () => {
+      const res = await request(app).post('/api/auth/refresh');
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 401 if refresh token is invalid', async () => {
+      prismaMock.refreshToken.findUnique.mockResolvedValue(null);
+      const res = await request(app)
+        .post('/api/auth/refresh')
+        .set('Cookie', 'refreshToken=bad.token.here');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('POST /api/auth/logout', () => {
+    it('should clear cookies and return 204 on logout', async () => {
+      prismaMock.refreshToken.deleteMany.mockResolvedValue({ count: 1 });
+
+      const refreshToken = jwt.sign({ userId: 'user-1' }, process.env.JWT_REFRESH_SECRET, { expiresIn: '7d' });
+      const res = await request(app)
+        .post('/api/auth/logout')
+        .set('Cookie', `refreshToken=${refreshToken}`);
+
+      expect(res.status).toBe(204);
+      // Cookies should be cleared
+      const setCookieHeader = res.headers['set-cookie'] || [];
+      const clearsAccess = setCookieHeader.some(c => c.startsWith('accessToken=;') || c.includes('accessToken=;'));
+      const clearsRefresh = setCookieHeader.some(c => c.startsWith('refreshToken=;') || c.includes('refreshToken=;'));
+      expect(clearsAccess || clearsRefresh).toBe(true);
+    });
+  });
+});

--- a/server/__tests__/users.test.js
+++ b/server/__tests__/users.test.js
@@ -1,0 +1,109 @@
+/**
+ * S2-1: User profile endpoint tests (TDD — written before implementation)
+ */
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('passport', () => ({
+  initialize: () => (req, res, next) => next(),
+  session: () => (req, res, next) => next(),
+  authenticate: () => (req, res, next) => next(),
+  use: jest.fn(),
+  serializeUser: jest.fn(),
+  deserializeUser: jest.fn(),
+}));
+
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    refreshToken: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    writer: {
+      findMany: jest.fn().mockResolvedValue([]),
+    },
+    $disconnect: jest.fn(),
+  };
+  return { PrismaClient: jest.fn(() => mockPrisma) };
+});
+
+const { PrismaClient } = require('@prisma/client');
+const prismaMock = new PrismaClient();
+
+const JWT_SECRET = 'test-secret';
+process.env.JWT_SECRET = JWT_SECRET;
+process.env.JWT_REFRESH_SECRET = 'test-refresh-secret';
+process.env.SESSION_SECRET = 'test-session-secret';
+process.env.GOOGLE_CLIENT_ID = 'mock-client-id';
+process.env.GOOGLE_CLIENT_SECRET = 'mock-client-secret';
+process.env.GOOGLE_CALLBACK_URL = 'http://localhost:3000/api/auth/google/callback';
+process.env.CLIENT_URL = 'http://localhost:5173';
+
+const app = require('../src/index');
+
+describe('User Profile Routes — S2-1', () => {
+  const makeToken = (userId = 'user-1') =>
+    jwt.sign({ userId }, JWT_SECRET, { expiresIn: '15m' });
+
+  describe('GET /api/users/:id', () => {
+    it('should return public profile for an existing user', async () => {
+      const mockUser = {
+        id: 'user-1',
+        displayName: 'Test User',
+        bio: 'Hello!',
+        avatarUrl: null,
+        createdAt: new Date().toISOString(),
+      };
+      prismaMock.user.findUnique.mockResolvedValue(mockUser);
+
+      const res = await request(app).get('/api/users/user-1');
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ id: 'user-1', displayName: 'Test User' });
+      // Email should NOT be exposed on public profile
+      expect(res.body.email).toBeUndefined();
+      expect(res.body.googleId).toBeUndefined();
+    });
+
+    it('should return 404 for a non-existent user', async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+      const res = await request(app).get('/api/users/nonexistent-id');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /api/users/me', () => {
+    it('should update the profile when authenticated', async () => {
+      const updatedUser = { id: 'user-1', displayName: 'New Name', bio: 'Updated bio', avatarUrl: null };
+      prismaMock.user.update.mockResolvedValue(updatedUser);
+
+      const res = await request(app)
+        .patch('/api/users/me')
+        .set('Cookie', `accessToken=${makeToken('user-1')}`)
+        .send({ displayName: 'New Name', bio: 'Updated bio' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.displayName).toBe('New Name');
+    });
+
+    it('should return 401 if not authenticated', async () => {
+      const res = await request(app)
+        .patch('/api/users/me')
+        .send({ displayName: 'Hacker' });
+      expect(res.status).toBe(401);
+    });
+
+    it('should return 400 if no valid fields are provided', async () => {
+      const res = await request(app)
+        .patch('/api/users/me')
+        .set('Cookie', `accessToken=${makeToken('user-1')}`)
+        .send({});
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -1,0 +1,33 @@
+const passport = require('passport');
+const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
+const { findOrCreateUser, generateTokens } = require('../services/auth.service');
+
+const COOKIE_OPTS = {
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+};
+
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      callbackURL: process.env.GOOGLE_CALLBACK_URL || 'http://localhost:3000/api/auth/google/callback',
+    },
+    async (accessToken, refreshToken, profile, done) => {
+      try {
+        const user = await findOrCreateUser(profile);
+        done(null, user);
+      } catch (err) {
+        done(err, null);
+      }
+    }
+  )
+);
+
+// We use JWT cookies — no need for passport session serialization
+passport.serializeUser((user, done) => done(null, user));
+passport.deserializeUser((user, done) => done(null, user));
+
+module.exports = { passport, COOKIE_OPTS };

--- a/server/src/controllers/auth.controller.js
+++ b/server/src/controllers/auth.controller.js
@@ -1,0 +1,102 @@
+const jwt = require('jsonwebtoken');
+const { PrismaClient } = require('@prisma/client');
+const { generateTokens, rotateRefreshToken, revokeAllRefreshTokens } = require('../services/auth.service');
+const prisma = new PrismaClient();
+
+const COOKIE_OPTS = {
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+};
+
+const ACCESS_COOKIE_OPTS = { ...COOKIE_OPTS, maxAge: 15 * 60 * 1000 }; // 15 min
+const REFRESH_COOKIE_OPTS = { ...COOKIE_OPTS, maxAge: 7 * 24 * 60 * 60 * 1000 }; // 7 days
+
+/**
+ * GET /api/auth/google
+ * Initiates the Google OAuth flow (handled by passport.authenticate in the route).
+ */
+const redirectToGoogle = (req, res) => {
+  // This is a no-op — passport.authenticate handles the redirect
+};
+
+/**
+ * GET /api/auth/google/callback
+ * Called by Google after user grants permission. Issues JWT cookies and redirects to client.
+ */
+const googleCallback = async (req, res) => {
+  try {
+    const user = req.user;
+    if (!user) return res.status(401).json({ error: 'OAuth authentication failed' });
+
+    const { accessToken, refreshToken } = await generateTokens(user.id);
+
+    res.cookie('accessToken', accessToken, ACCESS_COOKIE_OPTS);
+    res.cookie('refreshToken', refreshToken, REFRESH_COOKIE_OPTS);
+
+    const clientUrl = process.env.CLIENT_URL || 'http://localhost:5173';
+    return res.redirect(clientUrl);
+  } catch (err) {
+    console.error('googleCallback error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+/**
+ * POST /api/auth/refresh
+ * Validates refresh token cookie, issues a new access + refresh token pair (rotation).
+ */
+const refreshToken = async (req, res) => {
+  const token = req.cookies && req.cookies.refreshToken;
+  if (!token) return res.status(401).json({ error: 'No refresh token provided' });
+
+  try {
+    const { accessToken, refreshToken: newRefreshToken } = await rotateRefreshToken(token);
+    res.cookie('accessToken', accessToken, ACCESS_COOKIE_OPTS);
+    res.cookie('refreshToken', newRefreshToken, REFRESH_COOKIE_OPTS);
+    return res.status(200).json({ accessToken });
+  } catch (err) {
+    return res.status(401).json({ error: err.message || 'Invalid or expired refresh token' });
+  }
+};
+
+/**
+ * POST /api/auth/logout
+ * Revokes all refresh tokens for the user, clears cookies.
+ */
+const logout = async (req, res) => {
+  const token = req.cookies && req.cookies.refreshToken;
+
+  if (token) {
+    try {
+      const payload = jwt.verify(token, process.env.JWT_REFRESH_SECRET);
+      await revokeAllRefreshTokens(payload.userId);
+    } catch {
+      // Token may already be expired — still clear cookies
+    }
+  }
+
+  res.clearCookie('accessToken', COOKIE_OPTS);
+  res.clearCookie('refreshToken', COOKIE_OPTS);
+  return res.status(204).end();
+};
+
+/**
+ * GET /api/auth/me
+ * Returns the currently authenticated user (requires requireJwt middleware).
+ */
+const getMe = async (req, res) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.userId },
+      select: { id: true, displayName: true, email: true, bio: true, avatarUrl: true, createdAt: true },
+    });
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    return res.status(200).json(user);
+  } catch (err) {
+    console.error('getMe error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+module.exports = { redirectToGoogle, googleCallback, refreshToken, logout, getMe };

--- a/server/src/controllers/users.controller.js
+++ b/server/src/controllers/users.controller.js
@@ -1,0 +1,69 @@
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+/**
+ * GET /api/users/:id
+ * Returns a public user profile. Does not expose email or googleId.
+ */
+const getProfile = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        displayName: true,
+        bio: true,
+        avatarUrl: true,
+        createdAt: true,
+        writers: {
+          select: {
+            log: {
+              select: { id: true, title: true, category: true, status: true, createdAt: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) return res.status(404).json({ error: 'User not found' });
+
+    // Flatten writers → logs for a clean participation history
+    const participationHistory = (user.writers || []).map((w) => w.log);
+    return res.status(200).json({ ...user, writers: undefined, participationHistory });
+
+  } catch (err) {
+    console.error('getProfile error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+/**
+ * PATCH /api/users/me
+ * Allows authenticated users to update their own display name and bio.
+ */
+const updateProfile = async (req, res) => {
+  const { displayName, bio } = req.body;
+
+  if (!displayName && bio === undefined) {
+    return res.status(400).json({ error: 'No valid fields to update' });
+  }
+
+  const data = {};
+  if (displayName) data.displayName = displayName;
+  if (bio !== undefined) data.bio = bio;
+
+  try {
+    const user = await prisma.user.update({
+      where: { id: req.userId },
+      data,
+      select: { id: true, displayName: true, bio: true, avatarUrl: true, createdAt: true },
+    });
+    return res.status(200).json(user);
+  } catch (err) {
+    console.error('updateProfile error:', err);
+    return res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
+module.exports = { getProfile, updateProfile };

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2,19 +2,24 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const cookieParser = require('cookie-parser');
-const passport = require('passport');
 const session = require('express-session');
+const { passport } = require('./config/passport');
 const { sessionMiddleware } = require('./middleware/auth');
 const logsRouter = require('./routes/logs');
+const authRouter = require('./routes/auth.routes');
+const usersRouter = require('./routes/users.routes');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(cors());
+app.use(cors({
+    origin: process.env.CLIENT_URL || 'http://localhost:5173',
+    credentials: true,
+}));
 app.use(express.json());
 app.use(cookieParser());
 
-// Apply our custom session token middleware globally
+// Anonymous session token middleware (Sprint 1 — unchanged)
 app.use(sessionMiddleware);
 
 app.use(
@@ -29,6 +34,8 @@ app.use(passport.session());
 
 // API routes
 app.use('/api/logs', logsRouter);
+app.use('/api/auth', authRouter);
+app.use('/api/users', usersRouter);
 
 if (process.env.NODE_ENV !== 'production') {
     const devRouter = require('./routes/dev');

--- a/server/src/middleware/auth.js
+++ b/server/src/middleware/auth.js
@@ -1,6 +1,8 @@
 const { v4: uuidv4, validate: uuidValidate } = require('uuid');
 const { PrismaClient } = require('@prisma/client');
+const jwt = require('jsonwebtoken');
 const prisma = new PrismaClient();
+
 
 /**
  * sessionMiddleware
@@ -132,8 +134,29 @@ const requireWriter = async (req, res, next) => {
     }
 };
 
+/**
+ * requireJwt
+ * Verifies the JWT accessToken cookie. Attaches req.userId on success.
+ * Returns 401 if token is missing, expired, or invalid.
+ */
+const requireJwt = (req, res, next) => {
+    const token = req.cookies && req.cookies.accessToken;
+    if (!token) {
+        return res.status(401).json({ error: 'Unauthorized: No access token provided' });
+    }
+    try {
+        const payload = jwt.verify(token, process.env.JWT_SECRET);
+        req.userId = payload.userId;
+        next();
+    } catch {
+        return res.status(401).json({ error: 'Unauthorized: Invalid or expired access token' });
+    }
+};
+
 module.exports = {
     sessionMiddleware,
     requireAuth,
-    requireWriter
+    requireWriter,
+    requireJwt,
 };
+

--- a/server/src/routes/auth.routes.js
+++ b/server/src/routes/auth.routes.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const passport = require('passport');
+const { googleCallback, refreshToken, logout, getMe } = require('../controllers/auth.controller');
+const { requireJwt } = require('../middleware/auth');
+
+const router = express.Router();
+
+// Step 1: Redirect to Google
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+
+// Step 2: Google redirects back here with a code
+router.get(
+  '/google/callback',
+  passport.authenticate('google', { session: false, failureRedirect: `${process.env.CLIENT_URL || 'http://localhost:5173'}/login?error=oauth_failed` }),
+  googleCallback
+);
+
+// Token refresh
+router.post('/refresh', refreshToken);
+
+// Logout
+router.post('/logout', logout);
+
+// Current user
+router.get('/me', requireJwt, getMe);
+
+module.exports = router;

--- a/server/src/routes/users.routes.js
+++ b/server/src/routes/users.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { getProfile, updateProfile } = require('../controllers/users.controller');
+const { requireJwt } = require('../middleware/auth');
+
+const router = express.Router();
+
+// Public: view any user's profile
+router.get('/:id', getProfile);
+
+// Authenticated: update own profile
+router.patch('/me', requireJwt, updateProfile);
+
+module.exports = router;

--- a/server/src/services/auth.service.js
+++ b/server/src/services/auth.service.js
@@ -1,0 +1,74 @@
+const jwt = require('jsonwebtoken');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+const ACCESS_TOKEN_SECRET = process.env.JWT_SECRET;
+const REFRESH_TOKEN_SECRET = process.env.JWT_REFRESH_SECRET;
+const ACCESS_TOKEN_EXPIRY = '15m';
+const REFRESH_TOKEN_EXPIRY = '7d';
+const REFRESH_TOKEN_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Find an existing user by googleId, or create a new one from a Google profile.
+ */
+const findOrCreateUser = async (googleProfile) => {
+  const { id: googleId, displayName, emails, photos } = googleProfile;
+  const email = emails && emails[0] ? emails[0].value : null;
+  const avatarUrl = photos && photos[0] ? photos[0].value : null;
+
+  const user = await prisma.user.upsert({
+    where: { googleId },
+    update: { displayName, avatarUrl },
+    create: { googleId, email, displayName, avatarUrl },
+  });
+
+  return user;
+};
+
+/**
+ * Generate a JWT access token (short-lived) and a refresh token (long-lived).
+ * Stores the refresh token in the DB.
+ */
+const generateTokens = async (userId) => {
+  const accessToken = jwt.sign({ userId }, ACCESS_TOKEN_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRY });
+  const refreshToken = jwt.sign({ userId }, REFRESH_TOKEN_SECRET, { expiresIn: REFRESH_TOKEN_EXPIRY });
+
+  const expiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY_MS);
+  await prisma.refreshToken.create({
+    data: { token: refreshToken, userId, expiresAt },
+  });
+
+  return { accessToken, refreshToken };
+};
+
+/**
+ * Rotate a refresh token: verify it, delete the old one, issue a new pair.
+ */
+const rotateRefreshToken = async (oldToken) => {
+  let payload;
+  try {
+    payload = jwt.verify(oldToken, REFRESH_TOKEN_SECRET);
+  } catch {
+    throw new Error('Invalid refresh token');
+  }
+
+  const stored = await prisma.refreshToken.findUnique({ where: { token: oldToken } });
+  if (!stored || stored.expiresAt < new Date()) {
+    // Token not in DB or expired — revoke everything for this user
+    if (stored) await prisma.refreshToken.delete({ where: { token: oldToken } });
+    throw new Error('Refresh token expired or revoked');
+  }
+
+  // Delete old token and issue new pair
+  await prisma.refreshToken.delete({ where: { token: oldToken } });
+  return generateTokens(payload.userId);
+};
+
+/**
+ * Revoke all refresh tokens for a user (used on logout).
+ */
+const revokeAllRefreshTokens = async (userId) => {
+  await prisma.refreshToken.deleteMany({ where: { userId } });
+};
+
+module.exports = { findOrCreateUser, generateTokens, rotateRefreshToken, revokeAllRefreshTokens };


### PR DESCRIPTION
## Summary

Implements S2-1: full user accounts on top of the existing anonymous session flow.

### What's new
- **Prisma**: `User` model (googleId, email, displayName, bio, avatarUrl) + `RefreshToken` model. Optional `userId` FK on `Writer` to link anonymous sessions to accounts.
- **Google OAuth**: Passport.js strategy via `server/src/config/passport.js`. Callback issues JWT access (15m) + refresh (7d) cookies.
- **JWT middleware**: New `requireJwt` guard in `auth.js` — attaches `req.userId`, returns 401 on invalid/missing token.
- **Auth routes**: `GET /api/auth/google`, `/callback`, `/me`, `POST /refresh`, `POST /logout`
- **Users routes**: `GET /api/users/:id` (public profile + participation history), `PATCH /api/users/me` (authenticated)

### Tests
- 13 new tests in `auth.test.js` and `users.test.js` — all passing ✅
- All 5 pre-existing test suites pass unchanged ✅

Closes #16