### PR TITLE
[#9] Multilingual UI — Chinese / English / Spanish

### DIFF
--- a/client/src/__tests__/routing.test.jsx
+++ b/client/src/__tests__/routing.test.jsx
@@ -12,13 +12,13 @@ describe("Frontend Routing", () => {
 
     render(<RouterProvider router={router} />);
 
-    // Verify navigation links are present
-    expect(screen.getByRole("link", { name: /广场/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /新建/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /关于/i })).toBeInTheDocument();
+    // Verify navigation links are present (default lang = en)
+    expect(screen.getByRole("link", { name: /feed/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /new log/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /about/i })).toBeInTheDocument();
 
     // Verify home page content is rendering
-    expect(screen.getByText(/加载/i)).toBeInTheDocument();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
   it("navigates to the Create Log page when clicking 'write'", async () => {
@@ -29,8 +29,8 @@ describe("Frontend Routing", () => {
 
     render(<RouterProvider router={router} />);
 
-    // Click the write link
-    const writeLink = screen.getByRole("link", { name: /新建/i });
+    // Click the write link (default lang = en)
+    const writeLink = screen.getByRole("link", { name: /new log/i });
     await user.click(writeLink);
 
     // Verify URL change visually via rendered content

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,37 +1,52 @@
 import { Outlet, Link } from "react-router-dom";
+import { useLanguage } from "../context/LanguageContext";
+import { LANG_OPTIONS } from "../utils/i18n";
+import { S } from "../utils/styles";
 
 export default function Layout() {
+  const { lang, setLang, t } = useLanguage();
+
   return (
     <div style={{ maxWidth: '900px', margin: '0 auto', padding: '40px 20px' }}>
-      <header style={{ 
-        display: 'flex', 
-        justifyContent: 'space-between', 
+      <header style={{
+        display: 'flex',
+        justifyContent: 'space-between',
         alignItems: 'baseline',
         paddingBottom: '20px',
         borderBottom: '1px solid #eeeeee',
         marginBottom: '40px'
       }}>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px' }}>
-          <Link to="/" style={{ 
-            fontSize: '24px', 
-            fontWeight: 'bold', 
-            color: '#000', 
-            textDecoration: 'none' 
+          <Link to="/" style={{
+            fontSize: '24px',
+            fontWeight: 'bold',
+            color: '#000',
+            textDecoration: 'none'
           }}>
-            集体潜意识
+            Collective Unconscious
           </Link>
           <span style={{ fontSize: '14px', color: '#999' }}>
-            协作接龙写作
+            {t.tagline}
           </span>
         </div>
 
         <nav style={{ display: 'flex', gap: '20px', alignItems: 'center', fontSize: '16px' }}>
-          <Link to="/" style={{ color: '#0033cc' }}>广场</Link>
-          <Link to="/create" style={{ color: '#0033cc' }}>新建</Link>
-          <Link to="/about" style={{ color: '#0033cc' }}>关于</Link>
-          
-          <div style={{ marginLeft: '20px', color: '#ccc', fontSize: '14px' }}>
-            <span style={{ color: '#333' }}>中文</span> / <span>EN</span> / <span>ES</span>
+          <Link to="/" style={{ color: '#0033cc' }}>{t.nav.feed}</Link>
+          <Link to="/create" style={{ color: '#0033cc' }}>{t.nav.create}</Link>
+          <Link to="/about" style={{ color: '#0033cc' }}>{t.nav.about}</Link>
+
+          <div style={{ marginLeft: '20px', fontSize: '14px' }}>
+            {LANG_OPTIONS.map((l, i) => (
+              <span key={l.code}>
+                {i > 0 && <span style={{ color: '#ccc' }}> / </span>}
+                <button
+                  style={S.langBtn(lang === l.code)}
+                  onClick={() => setLang(l.code)}
+                >
+                  {l.label}
+                </button>
+              </span>
+            ))}
           </div>
         </nav>
       </header>

--- a/client/src/components/WriteZone.jsx
+++ b/client/src/components/WriteZone.jsx
@@ -1,23 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { randomNick } from '../utils/nickname';
+import { useLanguage } from '../context/LanguageContext';
 import './WriteZone.css';
 
 const DEFAULT_COLORS = ['#FF0000', '#FF8C00', '#0000FF', '#008000', '#800080', '#000000'];
 
 function WriteZone({ colorHex, perTurnLengthLimit = 500, onSubmit, myWriter = null }) {
+    const { t, lang } = useLanguage();
     const [content, setContent] = useState('');
     const [nickname, setNickname] = useState(myWriter?.nickname || '');
-    const [placeholderNick, setPlaceholderNick] = useState('');
     const [selectedColor, setSelectedColor] = useState(myWriter?.colorHex || colorHex || '#000000');
     const isReturningWriter = !!myWriter;
 
-    useEffect(() => {
-        setPlaceholderNick(randomNick());
-    }, []);
-
     const handleSubmit = async (e) => {
         e.preventDefault();
-        
+
         if (!content.trim() || content.length > perTurnLengthLimit) {
             return;
         }
@@ -25,7 +22,7 @@ function WriteZone({ colorHex, perTurnLengthLimit = 500, onSubmit, myWriter = nu
         if (onSubmit) {
             await onSubmit({ content, nickname: nickname.trim(), colorHex: selectedColor });
         }
-        
+
         setContent('');
         setNickname('');
     };
@@ -38,7 +35,7 @@ function WriteZone({ colorHex, perTurnLengthLimit = 500, onSubmit, myWriter = nu
                 <textarea
                     value={content}
                     onChange={(e) => setContent(e.target.value)}
-                    placeholder="Type your turn..."
+                    placeholder={t.log.placeholder}
                     className={isOverLimit ? 'over-limit' : ''}
                     style={{ color: selectedColor }}
                 />
@@ -50,7 +47,7 @@ function WriteZone({ colorHex, perTurnLengthLimit = 500, onSubmit, myWriter = nu
                         type="text"
                         value={nickname}
                         onChange={(e) => setNickname(e.target.value)}
-                        placeholder={`Nickname (e.g. ${placeholderNick})`}
+                        placeholder={`${t.log.nickLabel} ${randomNick(lang)}`}
                         className="nickname-input"
                         disabled={isReturningWriter}
                     />
@@ -75,12 +72,12 @@ function WriteZone({ colorHex, perTurnLengthLimit = 500, onSubmit, myWriter = nu
                             disabled={isReturningWriter}
                         />
                     </div>
-                    <button 
-                        type="submit" 
+                    <button
+                        type="submit"
                         disabled={!content.trim() || isOverLimit}
                         className="submit-button"
                     >
-                        Submit
+                        {t.log.submit}
                     </button>
                 </div>
             </form>

--- a/client/src/components/WriteZone.test.jsx
+++ b/client/src/components/WriteZone.test.jsx
@@ -14,10 +14,10 @@ describe('WriteZone Component', () => {
 
     it('renders a textarea, optional nickname input, and submit button', () => {
         renderWithClient(<WriteZone logId="123" colorHex="#FF0000" />);
-        
-        expect(screen.getByPlaceholderText(/Type your turn.../i)).toBeInTheDocument();
-        expect(screen.getByPlaceholderText(/Nickname \(e\.g\./i)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Submit/i })).toBeInTheDocument();
+
+        expect(screen.getByPlaceholderText(/continue the piece/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/your nickname:/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument();
     });
 
     it('calls onSubmit with user content and typed nickname', async () => {
@@ -26,10 +26,10 @@ describe('WriteZone Component', () => {
             <WriteZone logId="123" colorHex="#FF0000" onSubmit={mockSubmit} />
         );
 
-        fireEvent.change(getByPlaceholderText(/Type your turn.../i), { target: { value: 'My cool turn' } });
-        fireEvent.change(getByPlaceholderText(/Nickname \(e\.g\./i), { target: { value: 'Custom Nick' } });
-        
-        fireEvent.click(getByRole('button', { name: /Submit/i }));
+        fireEvent.change(getByPlaceholderText(/continue the piece/i), { target: { value: 'My cool turn' } });
+        fireEvent.change(getByPlaceholderText(/your nickname:/i), { target: { value: 'Custom Nick' } });
+
+        fireEvent.click(getByRole('button', { name: /submit/i }));
 
         await waitFor(() => {
             expect(mockSubmit).toHaveBeenCalledWith({ content: 'My cool turn', nickname: 'Custom Nick', colorHex: '#FF0000' });
@@ -40,8 +40,8 @@ describe('WriteZone Component', () => {
         const mockSubmit = vi.fn();
         renderWithClient(<WriteZone logId="123" colorHex="#000" onSubmit={mockSubmit} />);
 
-        const textarea = screen.getByPlaceholderText('Type your turn...');
-        const submitButton = screen.getByText('Submit');
+        const textarea = screen.getByPlaceholderText(/continue the piece/i);
+        const submitButton = screen.getByRole('button', { name: /submit/i });
 
         fireEvent.change(textarea, { target: { value: 'This is my turn.' } });
         fireEvent.click(submitButton);
@@ -61,15 +61,15 @@ describe('WriteZone Component', () => {
         );
 
         const longText = 'A'.repeat(51);
-        fireEvent.change(getByPlaceholderText(/Type your turn.../i), { target: { value: longText } });
-        
+        fireEvent.change(getByPlaceholderText(/continue the piece/i), { target: { value: longText } });
+
         const counter = getByText(/51 \/ 50/i);
         expect(counter).toBeInTheDocument();
         expect(counter).toHaveClass('error');
-        
-        const textarea = getByPlaceholderText(/Type your turn.../i);
+
+        const textarea = getByPlaceholderText(/continue the piece/i);
         expect(textarea).toHaveClass('over-limit');
-        
-        expect(getByRole('button', { name: /Submit/i })).toBeDisabled();
+
+        expect(getByRole('button', { name: /submit/i })).toBeDisabled();
     });
 });

--- a/client/src/context/LanguageContext.jsx
+++ b/client/src/context/LanguageContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useState } from 'react';
+import { T, CAT } from '../utils/i18n';
+
+// Maps API category values → CAT keys
+export const CAT_KEY_MAP = {
+  'Freewriting': 'freewriting',
+  'Haiku': 'haiku',
+  'Poem': 'poem',
+  'Short Novel': 'novel',
+};
+
+const LanguageContext = createContext({
+  lang: 'en',
+  setLang: () => {},
+  t: T['en'],
+  cat: CAT['en'],
+});
+
+export function LanguageProvider({ children }) {
+  const [lang, setLangState] = useState(
+    () => localStorage.getItem('lang') || 'en'
+  );
+
+  const setLang = (code) => {
+    localStorage.setItem('lang', code);
+    setLangState(code);
+  };
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t: T[lang], cat: CAT[lang] }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  return useContext(LanguageContext);
+}

--- a/client/src/context/LanguageContext.test.jsx
+++ b/client/src/context/LanguageContext.test.jsx
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LanguageProvider, useLanguage } from './LanguageContext';
+
+const wrapper = ({ children }) => <LanguageProvider>{children}</LanguageProvider>;
+
+describe('LanguageContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns lang = "en" by default', () => {
+    const { result } = renderHook(() => useLanguage(), { wrapper });
+    expect(result.current.lang).toBe('en');
+  });
+
+  it('setLang updates lang', () => {
+    const { result } = renderHook(() => useLanguage(), { wrapper });
+    act(() => {
+      result.current.setLang('es');
+    });
+    expect(result.current.lang).toBe('es');
+  });
+
+  it('t.nav.feed returns correct string for active lang', () => {
+    const { result } = renderHook(() => useLanguage(), { wrapper });
+    expect(result.current.t.nav.feed).toBe('feed');
+    act(() => {
+      result.current.setLang('zh');
+    });
+    expect(result.current.t.nav.feed).toBe('广场');
+  });
+
+  it('writes and reads lang from localStorage', () => {
+    const { result } = renderHook(() => useLanguage(), { wrapper });
+    act(() => {
+      result.current.setLang('es');
+    });
+    expect(localStorage.getItem('lang')).toBe('es');
+
+    // New render picks up persisted lang from localStorage
+    const { result: result2 } = renderHook(() => useLanguage(), { wrapper });
+    expect(result2.current.lang).toBe('es');
+  });
+});

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,13 +4,16 @@ import { RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import { router } from './router'
+import { LanguageProvider } from './context/LanguageContext'
 
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <LanguageProvider>
+        <RouterProvider router={router} />
+      </LanguageProvider>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/client/src/pages/CreateLogPage.jsx
+++ b/client/src/pages/CreateLogPage.jsx
@@ -1,11 +1,17 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useLanguage } from '../context/LanguageContext';
+import { CAT_KEY_MAP } from '../context/LanguageContext';
 
 // Default category value must match backend schema default
 const CATEGORIES = ['Freewriting', 'Haiku', 'Poem', 'Short Novel'];
 
+const TIMEOUT_VALUES = ['', '1h', '6h', '12h', '24h', '48h', '7d'];
+const PER_TURN_VALUES = ['', '1_sentence', '2_sentences', '1_paragraph', 'custom_word_count'];
+
 export default function CreateLogPage() {
     const navigate = useNavigate();
+    const { t, cat } = useLanguage();
 
     // Required fields
     const [title, setTitle] = useState('');
@@ -79,7 +85,7 @@ export default function CreateLogPage() {
             }
 
             const newLog = await res.json();
-            
+
             if (newLog.accessCode) {
                 setCreatedLogId(newLog.id);
                 setAccessCode(newLog.accessCode);
@@ -98,7 +104,7 @@ export default function CreateLogPage() {
         try {
             if (navigator.clipboard && navigator.clipboard.writeText) {
                 await navigator.clipboard.writeText(accessCode);
-                setCopyStatus('Copied!');
+                setCopyStatus(t.log.copied);
                 setTimeout(() => setCopyStatus(''), 2000);
             } else {
                 setCopyStatus('Manual copy: ' + accessCode);
@@ -116,7 +122,7 @@ export default function CreateLogPage() {
 
     return (
         <div style={{ padding: '24px', maxWidth: 600 }}>
-            <h1>Create a New Log</h1>
+            <h1>{t.create.title}</h1>
 
             {error && (
                 <p
@@ -130,7 +136,7 @@ export default function CreateLogPage() {
             {/* Title */}
             <div style={{ marginBottom: 16 }}>
                 <label htmlFor="log-title">
-                    <strong>Title *</strong>
+                    <strong>{t.create.logTitle} *</strong>
                 </label>
                 <br />
                 <input
@@ -138,7 +144,7 @@ export default function CreateLogPage() {
                     type="text"
                     value={title}
                     onChange={(e) => setTitle(e.target.value)}
-                    placeholder="Give your log a title..."
+                    placeholder={t.create.logTitlePh}
                     style={{ width: '100%', marginTop: 4 }}
                 />
             </div>
@@ -146,7 +152,7 @@ export default function CreateLogPage() {
             {/* Category */}
             <div style={{ marginBottom: 16 }}>
                 <label htmlFor="log-category">
-                    <strong>Category</strong>
+                    <strong>{t.create.category}</strong>
                 </label>
                 <br />
                 <select
@@ -157,7 +163,7 @@ export default function CreateLogPage() {
                 >
                     {CATEGORIES.map((c) => (
                         <option key={c} value={c}>
-                            {c}
+                            {cat[CAT_KEY_MAP[c]]}
                         </option>
                     ))}
                 </select>
@@ -165,7 +171,7 @@ export default function CreateLogPage() {
 
             {/* Access Mode */}
             <div style={{ marginBottom: 16 }}>
-                <strong>Access Mode</strong>
+                <strong>{t.create.access}</strong>
                 <div style={{ display: 'flex', gap: 16, marginTop: 4 }}>
                     <label>
                         <input
@@ -175,7 +181,7 @@ export default function CreateLogPage() {
                             checked={accessMode === 'OPEN'}
                             onChange={() => setAccessMode('OPEN')}
                         />{' '}
-                        Open
+                        {t.create.open}
                     </label>
                     <label>
                         <input
@@ -185,14 +191,14 @@ export default function CreateLogPage() {
                             checked={accessMode === 'PRIVATE'}
                             onChange={() => setAccessMode('PRIVATE')}
                         />{' '}
-                        Private
+                        {t.create.private}
                     </label>
                 </div>
             </div>
 
             {/* Turn Mode */}
             <div style={{ marginBottom: 16 }}>
-                <strong>Turn Mode</strong>
+                <strong>{t.create.turnMode}</strong>
                 <div style={{ display: 'flex', gap: 16, marginTop: 4 }}>
                     <label>
                         <input
@@ -202,7 +208,7 @@ export default function CreateLogPage() {
                             checked={turnMode === 'FREESTYLE'}
                             onChange={() => setTurnMode('FREESTYLE')}
                         />{' '}
-                        Freestyle
+                        {t.create.freestyle}
                     </label>
                     <label>
                         <input
@@ -212,7 +218,7 @@ export default function CreateLogPage() {
                             checked={turnMode === 'STRUCTURED'}
                             onChange={() => setTurnMode('STRUCTURED')}
                         />{' '}
-                        Structured
+                        {t.create.structured}
                     </label>
                 </div>
             </div>
@@ -225,7 +231,7 @@ export default function CreateLogPage() {
                 onClick={() => setShowAdvanced((v) => !v)}
                 style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '8px 0', color: 'inherit', fontSize: 14 }}
             >
-                {showAdvanced ? '▾' : '▸'} Advanced settings
+                {showAdvanced ? '▾' : '▸'} {t.create.advanced}
             </button>
 
             {showAdvanced && (
@@ -233,14 +239,14 @@ export default function CreateLogPage() {
                     {/* Seed */}
                     <div style={{ marginBottom: 12 }}>
                         <label htmlFor="log-seed">
-                            Seed / creative constraint
+                            {t.create.seed}
                         </label>
                         <br />
                         <textarea
                             id="log-seed"
                             value={seed}
                             onChange={(e) => setSeed(e.target.value)}
-                            placeholder="Optional starting prompt..."
+                            placeholder={t.create.seedPh}
                             style={{ width: '100%', marginTop: 4 }}
                         />
                     </div>
@@ -248,7 +254,7 @@ export default function CreateLogPage() {
                     {/* Participant Limit */}
                     <div style={{ marginBottom: 12 }}>
                         <label htmlFor="participant-limit">
-                            Participant limit (blank = unlimited, min 2 if set)
+                            {t.create.participantLimit}
                         </label>
                         <br />
                         <input
@@ -257,7 +263,7 @@ export default function CreateLogPage() {
                             min="2"
                             value={participantLimit}
                             onChange={(e) => setParticipantLimit(e.target.value)}
-                            placeholder="Unlimited"
+                            placeholder={t.create.unlimited}
                             style={{ maxWidth: 120, marginTop: 4 }}
                         />
                     </div>
@@ -265,7 +271,7 @@ export default function CreateLogPage() {
                     {/* Turn Limit */}
                     <div style={{ marginBottom: 12 }}>
                         <label htmlFor="turn-limit">
-                            Turn limit (blank = unlimited)
+                            {t.create.turnLimit}
                         </label>
                         <br />
                         <input
@@ -274,7 +280,7 @@ export default function CreateLogPage() {
                             min="1"
                             value={turnLimit}
                             onChange={(e) => setTurnLimit(e.target.value)}
-                            placeholder="Unlimited"
+                            placeholder={t.create.unlimited}
                             style={{ maxWidth: 120, marginTop: 4 }}
                         />
                     </div>
@@ -282,7 +288,7 @@ export default function CreateLogPage() {
                     {/* Turn Timeout */}
                     <div style={{ marginBottom: 12 }}>
                         <label htmlFor="turn-timeout">
-                            Turn timeout
+                            {t.create.timeout}
                         </label>
                         <br />
                         <select
@@ -291,20 +297,16 @@ export default function CreateLogPage() {
                             onChange={(e) => setTurnTimeout(e.target.value)}
                             style={{ marginTop: 4 }}
                         >
-                            <option value="">No timeout (default)</option>
-                            <option value="1h">Auto-skip after 1 hour</option>
-                            <option value="6h">Auto-skip after 6 hours</option>
-                            <option value="12h">Auto-skip after 12 hours</option>
-                            <option value="24h">Auto-skip after 24 hours</option>
-                            <option value="48h">Auto-skip after 48 hours</option>
-                            <option value="7d">Auto-skip after 7 days</option>
+                            {t.create.timeoutOpts.map((opt, i) => (
+                                <option key={i} value={TIMEOUT_VALUES[i]}>{opt}</option>
+                            ))}
                         </select>
                     </div>
 
                     {/* Per-turn Length Limit */}
                     <div style={{ marginBottom: 12 }}>
                         <label htmlFor="per-turn-length-limit">
-                            Per-turn length limit
+                            {t.create.perTurn}
                         </label>
                         <br />
                         <select
@@ -313,11 +315,9 @@ export default function CreateLogPage() {
                             onChange={(e) => setPerTurnLengthLimit(e.target.value)}
                             style={{ marginTop: 4 }}
                         >
-                            <option value="">No limit (default)</option>
-                            <option value="1_sentence">1 sentence</option>
-                            <option value="2_sentences">2 sentences</option>
-                            <option value="1_paragraph">1 paragraph</option>
-                            <option value="custom_word_count">Custom word count</option>
+                            {t.create.perTurnOpts.map((opt, i) => (
+                                <option key={i} value={PER_TURN_VALUES[i]}>{opt}</option>
+                            ))}
                         </select>
                     </div>
                 </div>
@@ -330,7 +330,7 @@ export default function CreateLogPage() {
                     onClick={handleSubmit}
                     disabled={isLoading}
                 >
-                    {isLoading ? 'Creating...' : 'Start Log'}
+                    {isLoading ? '...' : t.create.submit}
                 </button>
             </div>
 
@@ -357,12 +357,12 @@ export default function CreateLogPage() {
                         textAlign: 'center',
                         boxShadow: '0 4px 12px rgba(0,0,0,0.15)'
                     }}>
-                        <h2 style={{ marginTop: 0 }}>Private Log Created</h2>
-                        <p>Share this access code with participants you want to invite:</p>
-                        
-                        <div style={{ 
-                            fontSize: '32px', 
-                            fontWeight: 'bold', 
+                        <h2 style={{ marginTop: 0 }}>{t.access.title}</h2>
+                        <p>{t.access.desc}</p>
+
+                        <div style={{
+                            fontSize: '32px',
+                            fontWeight: 'bold',
                             letterSpacing: '4px',
                             margin: '24px 0',
                             padding: '12px',
@@ -373,16 +373,16 @@ export default function CreateLogPage() {
                         </div>
 
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
-                            <button 
+                            <button
                                 onClick={handleCopyCode}
                                 style={{ padding: '8px 16px', cursor: 'pointer' }}
                             >
-                                {copyStatus || 'Copy Code'}
+                                {copyStatus || t.log.copy}
                             </button>
-                            <button 
+                            <button
                                 onClick={handleDone}
-                                style={{ 
-                                    padding: '8px 16px', 
+                                style={{
+                                    padding: '8px 16px',
                                     cursor: 'pointer',
                                     border: 'none',
                                     backgroundColor: 'black',

--- a/client/src/pages/CreateLogPage.test.jsx
+++ b/client/src/pages/CreateLogPage.test.jsx
@@ -21,29 +21,29 @@ describe('CreateLogPage', () => {
         renderPage();
         expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/category/i)).toBeInTheDocument();
-        expect(screen.getByText(/access mode/i)).toBeInTheDocument();
+        expect(screen.getByText(/^access$/i)).toBeInTheDocument();
         expect(screen.getByText(/turn mode/i)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /start log/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^create$/i })).toBeInTheDocument();
     });
 
     it('hides advanced settings by default and shows them on toggle', () => {
         renderPage();
         expect(screen.queryByLabelText(/participant limit/i)).not.toBeInTheDocument();
         expect(screen.queryByLabelText(/turn timeout/i)).not.toBeInTheDocument();
-        expect(screen.queryByLabelText(/per-turn length limit/i)).not.toBeInTheDocument();
+        expect(screen.queryByLabelText(/per-turn limit/i)).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByText(/advanced settings/i));
 
         expect(screen.getByLabelText(/participant limit/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/turn limit/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/^turn limit$/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/seed/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/turn timeout/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/per-turn length limit/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/per-turn limit/i)).toBeInTheDocument();
     });
 
     it('shows an error when title is empty and does not call fetch', async () => {
         renderPage();
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
         expect(await screen.findByRole('alert')).toHaveTextContent('Title is required');
         expect(fetch).not.toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe('CreateLogPage', () => {
         fireEvent.change(screen.getByLabelText(/participant limit/i), {
             target: { value: '1' },
         });
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
         expect(await screen.findByRole('alert')).toHaveTextContent(
             'Participant limit must be at least 2'
@@ -74,7 +74,7 @@ describe('CreateLogPage', () => {
         renderPage();
 
         fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Great Log' } });
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
         await waitFor(() => {
             expect(fetch).toHaveBeenCalledWith(
@@ -95,15 +95,15 @@ describe('CreateLogPage', () => {
         renderPage();
 
         fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Secret Log' } });
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
-        // Modal should appear
-        expect(await screen.findByText(/private log created/i)).toBeInTheDocument();
+        // Modal should appear — uses t.access.title = "This is a private log"
+        expect(await screen.findByText(/this is a private log/i)).toBeInTheDocument();
         expect(screen.getByText('SECRET')).toBeInTheDocument();
 
         // Click Done to redirect
         fireEvent.click(screen.getByRole('button', { name: /done/i }));
-        // Redirection is handled by useNavigate which is harder to check in MemoryRouter without a custom wrapper, 
+        // Redirection is handled by useNavigate which is harder to check in MemoryRouter without a custom wrapper,
         // but we can trust the component calls it. (In a real set we'd check current location).
     });
 
@@ -118,13 +118,15 @@ describe('CreateLogPage', () => {
 
         renderPage();
         fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Copyable Log' } });
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
-        const copyBtn = await screen.findByRole('button', { name: /copy code/i });
+        // Modal uses t.log.copy = "copy link"
+        const copyBtn = await screen.findByRole('button', { name: /copy link/i });
         fireEvent.click(copyBtn);
 
         expect(writeText).toHaveBeenCalledWith('COPYME');
-        expect(await screen.findByText(/copied!/i)).toBeInTheDocument();
+        // t.log.copied = "copied"
+        expect(await screen.findByText(/^copied$/i)).toBeInTheDocument();
     });
 
     it('handles clipboard unavailability gracefully', async () => {
@@ -138,9 +140,9 @@ describe('CreateLogPage', () => {
 
         renderPage();
         fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'No Clipboard Log' } });
-        fireEvent.click(screen.getByRole('button', { name: /start log/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
-        const copyBtn = await screen.findByRole('button', { name: /copy code/i });
+        const copyBtn = await screen.findByRole('button', { name: /copy link/i });
         fireEvent.click(copyBtn);
 
         expect(screen.getByText(/manual copy: manual/i)).toBeInTheDocument();

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,16 +1,19 @@
 import { useState, useEffect } from 'react';
 import LogCard from '../components/LogCard';
 import { fetchLogs } from '../services/log.service';
+import { useLanguage } from '../context/LanguageContext';
+import { CAT_KEY_MAP } from '../context/LanguageContext';
+
+const CATEGORIES = ['Freewriting', 'Haiku', 'Poem', 'Short Novel'];
 
 export default function HomePage() {
+  const { t, cat } = useLanguage();
   const [logs, setLogs] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [canWriteOnly, setCanWriteOnly] = useState(false);
   const [category, setCategory] = useState('');
-
-  const CATEGORIES = ['Freewriting', 'Haiku', 'Poem', 'Short Novel'];
 
   useEffect(() => {
     const loadLogs = async () => {
@@ -22,7 +25,7 @@ export default function HomePage() {
         setError(null);
       } catch (err) {
         console.error('Failed to load logs', err);
-        setError('加载失败');
+        setError(t.feed.error);
       } finally {
         setLoading(false);
       }
@@ -34,7 +37,7 @@ export default function HomePage() {
   return (
     <div style={{ maxWidth: '720px' }}>
       <div style={{ marginBottom: '24px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span style={{ color: '#999', fontSize: '14px' }}>共 {total} 篇</span>
+        <span style={{ color: '#999', fontSize: '14px' }}>{t.feed.count(total)}</span>
         <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
           <select
             value={category}
@@ -48,9 +51,9 @@ export default function HomePage() {
               cursor: 'pointer',
             }}
           >
-            <option value=''>所有类型</option>
+            <option value=''>{t.feed.allCategories}</option>
             {CATEGORIES.map(c => (
-              <option key={c} value={c}>{c}</option>
+              <option key={c} value={c}>{cat[CAT_KEY_MAP[c]]}</option>
             ))}
           </select>
           <button
@@ -65,7 +68,7 @@ export default function HomePage() {
               cursor: 'pointer',
             }}
           >
-            可参与
+            {t.feed.canWrite}
           </button>
         </div>
       </div>
@@ -74,7 +77,7 @@ export default function HomePage() {
 
       <div className="discovery-feed">
         {logs.length === 0 && !loading && !error ? (
-          <p style={{ color: '#999' }}>暂无内容</p>
+          <p style={{ color: '#999' }}>{t.feed.empty}</p>
         ) : (
           logs.map(log => (
             <LogCard key={log.id} log={log} />
@@ -82,7 +85,7 @@ export default function HomePage() {
         )}
       </div>
 
-      {loading && <p style={{ color: '#999' }}>加载中...</p>}
+      {loading && <p style={{ color: '#999' }}>{t.feed.loading}</p>}
     </div>
   );
 }

--- a/client/src/pages/HomePage.test.jsx
+++ b/client/src/pages/HomePage.test.jsx
@@ -43,7 +43,7 @@ describe('HomePage Component', () => {
         });
 
         // Ensure total count logic works properly
-        expect(screen.getByText('共 4 篇')).toBeInTheDocument();
+        expect(screen.getByText('4 logs')).toBeInTheDocument();
     });
 
     it('shows error state if fetch fails', async () => {
@@ -54,7 +54,7 @@ describe('HomePage Component', () => {
         renderWithRouter(<HomePage />);
         
         await waitFor(() => {
-            expect(screen.getByText(/加载失败/i)).toBeInTheDocument();
+            expect(screen.getByText(/Failed to load/i)).toBeInTheDocument();
         });
         console.error.mockRestore();
     });

--- a/client/src/pages/LogDetailPage.jsx
+++ b/client/src/pages/LogDetailPage.jsx
@@ -4,6 +4,7 @@ import WriteZone from '../components/WriteZone';
 import { useState } from 'react';
 
 import { getLogById, closeLog } from '../services/log.service';
+import { useLanguage } from '../context/LanguageContext';
 
 const submitTurnApi = async ({ logId, content, nickname, colorHex, accessCode }) => {
     const res = await fetch(`/api/logs/${logId}/turns`, {
@@ -33,6 +34,7 @@ const skipTurnApi = async (logId) => {
 export default function LogDetailPage() {
     const { id } = useParams();
     const queryClient = useQueryClient();
+    const { t } = useLanguage();
     const [submitError, setSubmitError] = useState('');
     const [accessCode, setAccessCode] = useState('');
     // Tracks which writer the creator has selected to skip (defaults to nextWriter)
@@ -117,13 +119,13 @@ export default function LogDetailPage() {
                                 color: '#c00',
                             }}
                         >
-                            Close Log
+                            {t.log.close}
                         </button>
                     )}
                 </div>
                 <div style={{ color: '#666', fontSize: 14 }}>
-                    Mode: {log.turnMode} &middot; Status: {log.status}
-                    {log.turnLimit && <span> &middot; Turn Limit: {log.turnLimit}</span>}
+                    {t.log.mode(log.turnMode?.toLowerCase())} &middot; {log.status}
+                    {log.turnLimit && <span> &middot; {t.log.round(log.turns?.length ?? 0, log.turnLimit)}</span>}
                 </div>
             </div>
 
@@ -143,13 +145,13 @@ export default function LogDetailPage() {
                     })}
                 </div>
             ) : (
-                <p style={{ color: '#666', fontStyle: 'italic', marginBottom: 40 }}>No turns written yet.</p>
+                <p style={{ color: '#666', fontStyle: 'italic', marginBottom: 40 }}>{t.log.empty}</p>
             )}
 
             {/* Write zone / completed state */}
             {isCompleted ? (
                 <div style={{ padding: 24, textAlign: 'center', backgroundColor: '#f9f9f9', borderTop: '2px solid #ccc', fontWeight: 'bold' }}>
-                    <p style={{ margin: '0 0 16px 0' }}>This log has been completed.</p>
+                    <p style={{ margin: '0 0 16px 0' }}>{t.log.completed}</p>
                     <div style={{ display: 'flex', justifyContent: 'center', gap: 24, fontSize: 28, fontWeight: 'normal', color: '#666' }}>
                         <span style={{ cursor: 'pointer' }} title="Spark">✦</span>
                         <span style={{ cursor: 'pointer' }} title="Ripple">◎</span>
@@ -169,13 +171,13 @@ export default function LogDetailPage() {
                     {log.isMyTurn && log.accessMode === 'PRIVATE' && !log.myWriter ? (
                         <div style={{ marginBottom: 16 }}>
                             <p style={{ fontSize: 14, color: '#555', marginBottom: 8 }}>
-                                This is a private log. Enter the access code to join:
+                                {t.access.title}. {t.access.desc}
                             </p>
                             <input
                                 type="text"
                                 value={accessCode}
                                 onChange={(e) => setAccessCode(e.target.value)}
-                                placeholder="Access code"
+                                placeholder={t.access.placeholder}
                                 style={{
                                     padding: '6px 10px',
                                     fontSize: 14,
@@ -206,10 +208,10 @@ export default function LogDetailPage() {
                     ) : (
                         <div style={{ padding: '20px 0', color: '#888', fontStyle: 'italic', fontSize: 14 }}>
                             {log.nextWriter && (log.writers || []).length > 1
-                                ? <>Waiting for <strong style={{ color: log.nextWriter.colorHex }}>{log.nextWriter.nickname || 'Anonymous'}</strong> to write...</>
+                                ? <><strong style={{ color: log.nextWriter.colorHex }}>{t.log.turnOf(log.nextWriter.nickname || 'Anonymous')}</strong></>
                                 : log.nextWriter
-                                    ? 'Waiting for the next one to write...'
-                                    : 'Waiting for the first writer...'}
+                                    ? t.log.waitingNext
+                                    : t.log.waitingFirst}
                         </div>
                     )}
 

--- a/client/src/pages/LogDetailPage.test.jsx
+++ b/client/src/pages/LogDetailPage.test.jsx
@@ -62,9 +62,9 @@ describe('LogDetailPage Component', () => {
         
         // Assert "This log has been completed" is visible
         expect(screen.getByText(/This log has been completed/i)).toBeInTheDocument();
-        
+
         // Assert WriteZone is NOT rendered by checking for the submit button or textarea
-        expect(screen.queryByPlaceholderText('Type your turn...')).not.toBeInTheDocument();
+        expect(screen.queryByPlaceholderText(/continue the piece/i)).not.toBeInTheDocument();
     });
 
     it('handles the submit flow successfully on an active log', async () => {
@@ -91,8 +91,8 @@ describe('LogDetailPage Component', () => {
         render(<LogDetailPage />);
 
         // The WriteZone is rendered because it's ACTIVE
-        const textarea = screen.getByPlaceholderText('Type your turn...');
-        const submitButton = screen.getByRole('button', { name: /Submit/i });
+        const textarea = screen.getByPlaceholderText(/continue the piece/i);
+        const submitButton = screen.getByRole('button', { name: /submit/i });
 
         fireEvent.change(textarea, { target: { value: 'A new contribution' } });
         fireEvent.click(submitButton);

--- a/client/src/utils/i18n.ts
+++ b/client/src/utils/i18n.ts
@@ -9,7 +9,7 @@ export const T: any = {
   zh: {
     siteName: "集体潜意识", tagline: "协作接龙写作",
     nav: { feed: "广场", create: "新建", about: "关于" },
-    feed: { count: (n: any) => `共 ${n} 篇`, status: { active: "进行中", completed: "已完成" } },
+    feed: { count: (n: any) => `共 ${n} 篇`, status: { active: "进行中", completed: "已完成" }, allCategories: "所有类型", canWrite: "可参与", empty: "暂无内容", loading: "加载中...", error: "加载失败" },
     log: {
       structured: "回合制", freestyle: "自由模式",
       turnOf: (name: any) => `等待 ${name} 的回合`, yourTurn: "轮到你了",
@@ -19,6 +19,8 @@ export const T: any = {
       round: (c: any, t: any) => t ? `第 ${c}/${t} 轮` : `第 ${c} 轮`,
       queue: "顺序", copy: "复制链接", copied: "已复制",
       mode: (m: any) => m === "structured" ? "回合制" : "自由模式",
+      close: "关闭 Log", waitingFirst: "等待第一位写作者...", waitingNext: "等待下一位写作者...",
+      empty: "还没有内容。", completed: "这篇 Log 已完结。",
     },
     create: {
       title: "新建 Log", logTitle: "标题", logTitlePh: "给这篇起个名字",
@@ -42,7 +44,7 @@ export const T: any = {
   en: {
     siteName: "Collective Unconscious", tagline: "collaborative chain-writing",
     nav: { feed: "feed", create: "new log", about: "about" },
-    feed: { count: (n: any) => `${n} logs`, status: { active: "active", completed: "completed" } },
+    feed: { count: (n: any) => `${n} logs`, status: { active: "active", completed: "completed" }, allCategories: "All", canWrite: "Can write", empty: "Nothing here yet", loading: "Loading...", error: "Failed to load" },
     log: {
       structured: "structured", freestyle: "freestyle",
       turnOf: (name: any) => `waiting for ${name}`, yourTurn: "your turn",
@@ -52,6 +54,8 @@ export const T: any = {
       round: (c: any, t: any) => t ? `round ${c}/${t}` : `round ${c}`,
       queue: "queue", copy: "copy link", copied: "copied",
       mode: (m: any) => m === "structured" ? "structured" : "freestyle",
+      close: "Close Log", waitingFirst: "Waiting for the first writer...", waitingNext: "Waiting for the next one...",
+      empty: "No turns written yet.", completed: "This log has been completed.",
     },
     create: {
       title: "New Log", logTitle: "Title", logTitlePh: "give it a name",
@@ -75,7 +79,7 @@ export const T: any = {
   es: {
     siteName: "Inconsciente Colectivo", tagline: "escritura colaborativa en cadena",
     nav: { feed: "plaza", create: "crear", about: "acerca de" },
-    feed: { count: (n: any) => `${n} logs`, status: { active: "en curso", completed: "completado" } },
+    feed: { count: (n: any) => `${n} logs`, status: { active: "en curso", completed: "completado" }, allCategories: "Todas", canWrite: "Puedo escribir", empty: "Nada aquí aún", loading: "Cargando...", error: "Error al cargar" },
     log: {
       structured: "por turnos", freestyle: "libre",
       turnOf: (name: any) => `esperando a ${name}`, yourTurn: "tu turno",
@@ -85,6 +89,8 @@ export const T: any = {
       round: (c: any, t: any) => t ? `ronda ${c}/${t}` : `ronda ${c}`,
       queue: "orden", copy: "copiar enlace", copied: "copiado",
       mode: (m: any) => m === "structured" ? "por turnos" : "libre",
+      close: "Cerrar Log", waitingFirst: "Esperando al primer escritor...", waitingNext: "Esperando al siguiente...",
+      empty: "Aún no hay turnos.", completed: "Este log ha sido completado.",
     },
     create: {
       title: "Nuevo Log", logTitle: "Título", logTitlePh: "dale un nombre",


### PR DESCRIPTION
close #9 
- Add LanguageContext with localStorage persistence, default lang 'en'
- Wire real language switcher in Layout (中文 / EN / ES)
- Localize HomePage, CreateLogPage, LogDetailPage, WriteZone
- Add missing i18n keys (feed.allCategories/canWrite/empty/loading/error, log.close/waitingFirst/waitingNext/empty/completed)
- Pass lang to randomNick() for localized placeholder nicknames
- Keep 'Collective Unconscious' as fixed header across all languages
- Update all affected tests to match new English i18n strings