### PR TITLE
feat(client): S1-12 responsive mobile-first layout across all screens

### DIFF
--- a/client/src/__tests__/responsive.test.jsx
+++ b/client/src/__tests__/responsive.test.jsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to, style }) => <a href={to} style={style}>{children}</a>,
+  useParams: () => ({ id: 'mock-id' }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: vi.fn(() => ({ isLoading: false, isError: false, data: null })),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('../context/LanguageContext', () => ({
+  useLanguage: () => ({
+    t: {
+      siteName: 'Collective Unconscious', tagline: '', nav: { feed: 'feed', create: 'create', about: 'about' },
+      log: { placeholder: 'continue the piece', submit: 'submit', nickLabel: 'nickname', completed: 'completed',
+             mode: () => '', round: () => '', turnOf: () => '', waitingNext: '', waitingFirst: '', empty: '',
+             copy: 'copy', copied: 'copied', close: 'close' },
+      create: { title: 'Create', logTitle: 'Title', logTitlePh: '', category: 'Category', access: 'Access',
+                open: 'Open', private: 'Private', turnMode: 'Turn mode', freestyle: 'Freestyle',
+                structured: 'Structured', advanced: 'Advanced', seed: 'Seed', seedPh: '', participantLimit: 'Limit',
+                unlimited: 'Unlimited', turnLimit: 'Turn limit', timeout: 'Timeout', timeoutOpts: ['None'],
+                perTurn: 'Per turn', perTurnOpts: ['None'], submit: 'Create log' },
+      access: { title: 'Access code', desc: '', placeholder: '' },
+      feed: { count: () => '' },
+    },
+    lang: 'en',
+    cat: {},
+    setLang: vi.fn(),
+  }),
+  CAT_KEY_MAP: {},
+}));
+
+vi.mock('../utils/i18n', () => ({
+  LANG_OPTIONS: [{ code: 'en', label: 'EN' }],
+  CAT: { en: {} },
+}));
+
+vi.mock('../services/auth.service', () => ({
+  getMe: vi.fn(() => Promise.resolve(null)),
+  loginWithGoogle: vi.fn(),
+  logout: vi.fn(),
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+import Header from '../components/Header';
+import CreateLogPage from '../pages/CreateLogPage';
+
+describe('Responsive Design (S1-12)', () => {
+  it('Header renders with responsive class', () => {
+    render(<Header t={{ siteName: 'CU', tagline: '', nav: { feed: 'feed', create: 'create', about: 'about' } }} lang="en" setLang={vi.fn()} />);
+    const header = document.querySelector('header');
+    expect(header).toBeInTheDocument();
+    expect(header.classList.contains('site-header')).toBe(true);
+  });
+
+  it('Header nav has responsive class', () => {
+    render(<Header t={{ siteName: 'CU', tagline: '', nav: { feed: 'feed', create: 'create', about: 'about' } }} lang="en" setLang={vi.fn()} />);
+    const nav = document.querySelector('nav');
+    expect(nav.classList.contains('site-nav')).toBe(true);
+  });
+
+  it('CreateLogPage form is wrapped in responsive container', () => {
+    render(<CreateLogPage />);
+    const form = document.querySelector('.create-form');
+    expect(form).toBeInTheDocument();
+  });
+
+  it('submit button in CreateLogPage meets 44px min touch target via class', () => {
+    render(<CreateLogPage />);
+    const btn = screen.getByRole('button', { name: /create log/i });
+    expect(btn.classList.contains('touch-target')).toBe(true);
+  });
+});

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -19,45 +19,47 @@ export default function Header({ t, lang, setLang }) {
   };
 
   return (
-    <div style={S.header}>
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
-        <Link to="/" style={{ ...S.link, textDecoration: 'none', fontWeight: 'bold' }}>
+    <header className="site-header">
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '12px' }}>
+        <Link to="/" style={{
+          fontSize: '24px',
+          fontWeight: 'bold',
+          color: '#000',
+          textDecoration: 'none'
+        }}>
           {t.siteName}
         </Link>
-        <span style={S.muted}>{t.tagline}</span>
+        <span style={{ fontSize: '14px', color: '#999' }}>
+          {t.tagline}
+        </span>
       </div>
-      <div style={{ display: 'flex', gap: 12, alignItems: 'baseline', fontSize: 14 }}>
-        <Link to="/" style={S.link}>{t.nav.feed}</Link>
-        <Link to="/create" style={S.link}>{t.nav.create}</Link>
-        <Link to="/about" style={S.link}>{t.nav?.about || 'about'}</Link>
-        <span style={{ color: '#ccc' }}>|</span>
 
-        {/* Language toggle */}
-        <div style={{ display: 'flex', gap: 6 }}>
+      <nav className="site-nav">
+        <Link to="/" style={{ color: '#0033cc' }}>{t.nav.feed}</Link>
+        <Link to="/create" style={{ color: '#0033cc' }}>{t.nav.create}</Link>
+        <Link to="/about" style={{ color: '#0033cc' }}>{t.nav?.about || 'about'}</Link>
+
+        <div style={{ marginLeft: '20px', fontSize: '14px' }}>
           {LANG_OPTIONS.map((l, i) => (
-            <span key={l.code} style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+            <span key={l.code}>
+              {i > 0 && <span style={{ color: '#ccc' }}> / </span>}
               <button style={S.langBtn(lang === l.code)} onClick={() => setLang(l.code)}>
                 {l.label}
               </button>
-              {i < LANG_OPTIONS.length - 1 && (
-                <span style={{ color: '#ccc', fontSize: 12 }}>/</span>
-              )}
             </span>
           ))}
         </div>
 
-        <span style={{ color: '#ccc' }}>|</span>
-
         {/* Auth section */}
         {user === undefined ? null : user ? (
           <>
-            <Link to={`/users/${user.id}`} style={S.link}>{user.displayName}</Link>
-            <button style={S.link} onClick={handleLogout}>sign out</button>
+            <Link to={`/users/${user.id}`} style={{ color: '#0033cc' }}>{user.displayName}</Link>
+            <button style={{ ...S.link, color: '#0033cc' }} onClick={handleLogout}>sign out</button>
           </>
         ) : (
-          <button style={S.link} onClick={loginWithGoogle}>sign in</button>
+          <button style={{ ...S.link, color: '#0033cc' }} onClick={loginWithGoogle}>sign in</button>
         )}
-      </div>
-    </div>
+      </nav>
+    </header>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
+import './responsive.css'
 import { router } from './router'
 import { LanguageProvider } from './context/LanguageContext'
 

--- a/client/src/pages/CreateLogPage.jsx
+++ b/client/src/pages/CreateLogPage.jsx
@@ -121,7 +121,7 @@ export default function CreateLogPage() {
     };
 
     return (
-        <div style={{ padding: '24px', maxWidth: 600 }}>
+        <div className="create-form">
             <h1>{t.create.title}</h1>
 
             {error && (
@@ -329,6 +329,7 @@ export default function CreateLogPage() {
                     type="button"
                     onClick={handleSubmit}
                     disabled={isLoading}
+                    className="touch-target"
                 >
                     {isLoading ? '...' : t.create.submit}
                 </button>

--- a/client/src/pages/LogDetailPage.jsx
+++ b/client/src/pages/LogDetailPage.jsx
@@ -139,7 +139,7 @@ export default function LogDetailPage() {
     const resolvedSkipTarget = skipTargetId || (log.nextWriter?.id ?? '');
 
     return (
-        <div style={{ maxWidth: 800, margin: '0 auto', padding: '40px 20px' }}>
+        <div className="log-detail">
             {/* Header */}
             <div style={{ borderBottom: '2px solid #ccc', paddingBottom: 16, marginBottom: 24 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>

--- a/client/src/responsive.css
+++ b/client/src/responsive.css
@@ -1,0 +1,121 @@
+/* ─── Responsive / Mobile-first styles (S1-12) ─────────────────────────────
+   Breakpoints:
+     mobile-first  < 480px   (default)
+     tablet        ≥ 640px
+     desktop       ≥ 1024px
+─────────────────────────────────────────────────────────────────────────── */
+
+/* ── Touch targets ──────────────────────────────────────────────────────── */
+.touch-target {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 10px 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Site header ────────────────────────────────────────────────────────── */
+.site-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-bottom: 1px solid #eeeeee;
+  margin-bottom: 24px;
+}
+
+.site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  font-size: 16px;
+}
+
+@media (min-width: 640px) {
+  .site-header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0 0 20px 0;
+    margin-bottom: 40px;
+  }
+
+  .site-nav {
+    gap: 20px;
+  }
+}
+
+/* ── Log detail ─────────────────────────────────────────────────────────── */
+.log-detail {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px 16px;
+}
+
+@media (min-width: 640px) {
+  .log-detail {
+    padding: 40px 20px;
+  }
+}
+
+/* ── Create form ────────────────────────────────────────────────────────── */
+.create-form {
+  padding: 16px;
+  max-width: 600px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 640px) {
+  .create-form {
+    padding: 24px;
+  }
+}
+
+/* ── Feed ───────────────────────────────────────────────────────────────── */
+.feed-list {
+  padding: 12px 16px;
+  max-width: 640px;
+}
+
+/* ── WriteZone mobile ───────────────────────────────────────────────────── */
+@media (max-width: 479px) {
+  .write-zone-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .write-zone-controls .nickname-input {
+    width: 100%;
+  }
+
+  .submit-button {
+    min-height: 44px;
+    width: 100%;
+  }
+
+  .color-picker {
+    flex-wrap: wrap;
+  }
+}
+
+/* ── Global inputs / buttons touch sizing on mobile ────────────────────── */
+@media (max-width: 479px) {
+  input[type="text"],
+  input[type="number"],
+  input[type="email"],
+  select,
+  textarea {
+    font-size: 16px; /* prevents iOS auto-zoom */
+    min-height: 44px;
+    padding: 10px 8px;
+    box-sizing: border-box;
+    width: 100%;
+  }
+
+  button {
+    min-height: 44px;
+  }
+}


### PR DESCRIPTION
- Add responsive.css with breakpoints (mobile <480px, tablet ≥640px)
- .site-header / .site-nav: stacked on mobile, row on tablet+
- .create-form: full-width padded container
- .log-detail: responsive padding
- .touch-target: 44px min touch-target for submit buttons
- WriteZone controls stack vertically on mobile
- Global inputs use font-size:16px to prevent iOS auto-zoom

Closes #12